### PR TITLE
Avoid to pass "_token" value through query string

### DIFF
--- a/src/AdamWathan/Form/Elements/FormOpen.php
+++ b/src/AdamWathan/Form/Elements/FormOpen.php
@@ -16,7 +16,7 @@ class FormOpen extends Element
         $result .= $this->renderAttributes();
         $result .= '>';
 
-        if ($this->hasToken()) {
+        if ($this->hasToken() && ($this->attributes['method'] !== 'GET')) {
             $result .= $this->token->render();
         }
 


### PR DESCRIPTION
This patch prevent urls like http://blog.local/admin/posts/?_token=FGeYWnYVdmy7HEBret1OprY3IAYCzdNi3ESlINCG&status=active&name=test
